### PR TITLE
potential typo - rename --> renamed in Rename[A]

### DIFF
--- a/_posts/2015-04-29-f-bounds.md
+++ b/_posts/2015-04-29-f-bounds.md
@@ -170,7 +170,7 @@ trait Pet {
 }
 
 trait Rename[A] {
-  def rename(a: A, newName: String): A
+  def renamed(a: A, newName: String): A
 }
 ```
 


### PR DESCRIPTION
we have

```
    implicit val FishRename = new Rename[Fish] {
      def renamed(a: Fish, newName: String) = a.copy(name = newName)
    }
```

while in the definition of `Rename` trait

```
new Rename[Fish] {
    def rename(a: Fish, newName: String) = a.copy(name = newName)
  }
```

so looks like both should have the same name..
